### PR TITLE
Add basic Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.18-alpine3.15
+
+WORKDIR /go/src/github.com/go-js-yourself/gjsy
+
+COPY go.mod .
+RUN go mod download

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: test build docker-image
+
+default: test build
+
+docker-image:
+	DOCKER_BUILDKIT=1 docker build -t gjsy .
+
+test: docker-image
+	docker run -v $$PWD:/build --rm gjsy go test ./...
+
+build: docker-image
+	docker run --name gjsy-build -v $$PWD:/build -e CGO_ENABLED=0 gjsy \
+		go install ./... && ls -alsh
+	docker cp gjsy-build:/go/bin/repl .
+	docker rm gjsy-build
+


### PR DESCRIPTION
Adding a minimal `Makefile` to build the project and run tests in a Dockerized environment.

Closes #5 